### PR TITLE
initial code for feed to render

### DIFF
--- a/client/src/components/FeedList/index.js
+++ b/client/src/components/FeedList/index.js
@@ -3,15 +3,17 @@ import Thumbnail from "../Thumbnail";
 import { Container, Row, Col } from "../Grid";
 
 // For entire feed of FeedItem components
-export default function FeedList({ children }) {
+export function FeedList({ children }) {
     return <ul className="list-group">{children}</ul>
 }
 
 // For each event just scheduled or just completed
-export function FeedItem({
+export function FeedListItem({
     //later replace with hybrid image of both participating players
     thumbnail = "https://placehold.it/300x300",
-    message
+    organizer,
+    date,
+    time
 }) {
     return (
         <li className="list-group-item">
@@ -21,7 +23,7 @@ export function FeedItem({
                         <Thumbnail src={thumbnail} />
                     </Col>
                     <Col size="xs-8 sm-9">
-                        <p>{message}</p>
+                        <p>{organizer} scheduled a match for {date} at {time}.</p>
                     </Col>
                 </Row>
             </Container>

--- a/client/src/pages/feed.js
+++ b/client/src/pages/feed.js
@@ -1,21 +1,58 @@
 import React from "react";
 import Nav from "../components/Nav";
-import FeedList from "../components/FeedList";
+import { FeedList, FeedListItem } from "../components/FeedList";
+import { Container, Row, Col } from "../components/Grid";
 
 class Feed extends React.Component {
     state = {
-        navValue: "tab-one"
+        navValue: "tab-one",
+        matches: []
+    }
+
+    componentDidMount() {
+        this.getDates();
+    }
+
+    getDates = () => {
+        fetch("/api/calendar")
+            .then(res => res.json())
+            .then((dates) => {
+                console.log(dates);
+                this.setState({ matches: dates })
+            })
+            .catch(err => console.log(err));
     }
 
     render() {
         return (
             <div>
-                <Nav 
-                value={this.state.navValue}
+                <Nav
+                    value={this.state.navValue}
                 />
-                <FeedList/>
+                <Container>
+                    <FeedListItem />
+                    {/* <Row>
+                        <Col size="xs-12">
+                            {!this.state.matches.length ? (
+                                <h4 className="text-center">No scheduled matches</h4>
+                            ) : (
+                                    <FeedList>
+                                        {this.state.matches.map(match => {
+                                            return (
+                                                <FeedListItem
+                                                    organizer={match.userID}
+                                                    date={match.newDate}
+                                                />
+                                            );
+                                        })}
+                                    </FeedList>
+                                )}
+                        </Col>
+                    </Row> */}
+                </Container>
+
             </div>
-            
+
         );
     }
 }


### PR DESCRIPTION
I'm setting up the mapping that will render the feed, but I need some help for where we will be pull the data and which API route. In this request, part of what I wrote out is in client/src/FeedList. In there, I will have a placeholder image, and the current general format I think could be {organizer} scheduled a match for {date} at {time}. But we can figure out different things to announce in the feed, including match partner, but I don't think we are collecting users' names when we schedule events so we can hold off on that. 

This FeedListItem is being rendered in pages/feed.js, where I put in a dummy feed card on line 33, and commented out the mapping function from 34-51 that pulls cards from the API called on line 17. I held off on determining which API we should be pulling dates from, but the skeleton of the code is there for now, we'll just have to format it according to which API route we will be using for these cards, and what info is passed into it. We can discuss later, but if you know exactly which route we'd be using for this section, and the necessary variables that are provided in its JSON, feel free to take a stab at it!